### PR TITLE
Remove id field from pages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,15 +14,18 @@
     , rust-overlay
     }:
 
-    flake-utils.lib.eachDefaultSystem (system:
     let
+      cargoSha256 = "sha256-LBNvi9HTSKZb+OdFn4nmidUAqvdDlNJF1PnqYgw+2E0=";
+
       overlays = [
         (import rust-overlay)
         (self: super: {
           rustToolchain = super.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         })
       ];
-
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+    let
       pkgs = import nixpkgs { inherit system overlays; };
       inherit (pkgs) mkShell writeScriptBin;
 
@@ -46,7 +49,7 @@
       packages.default = pkgs.rustPlatform.buildRustPackage {
         name = "jelly";
         src = ./.;
-        cargoSha256 = "sha256-LBNvi9HTSKZb+OdFn4nmidUAqvdDlNJF1PnqYgw+2E0=";
+        inherit cargoSha256;
       };
 
       devShells.default = mkShell {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,12 @@ pub fn get_pages_in_dir(dir: &Path, config: &Config) -> Result<Vec<Page>, Conten
         let path = entry.path();
         let meta = metadata(&path)?;
         if meta.is_file() {
-            let page = Page::from_path(&path, config)?;
-            pages.push(page);
+            let ext = path.extension();
+
+            if ext.is_some() && ext.unwrap().to_string_lossy().ends_with("md") {
+                let page = Page::from_path(&path, config)?;
+                pages.push(page);
+            }
         }
     }
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -9,7 +9,6 @@ use std::path::Path;
 
 #[derive(Debug)]
 pub struct Page {
-    pub id: String,
     pub path: String,
     pub relative_path: String,
     pub title: String,
@@ -31,8 +30,6 @@ impl Page {
 
         let title: String = infer_page_title(front, path, &config.title_config);
 
-        let id = base64::encode(&title);
-
         let relative_path = path.strip_prefix(&config.root)?.to_string_lossy();
 
         let options = ComrakOptions::default();
@@ -40,7 +37,6 @@ impl Page {
         let html = markdown_to_html(&result.content, &options);
 
         Ok(Page {
-            id,
             path: String::from(path.to_string_lossy()),
             relative_path: String::from(relative_path),
             title,


### PR DESCRIPTION
Eventually I'd like to have an `id` field but I need to investigate how other systems do it.
