### PR TITLE
Fix root section issue

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::fs::{metadata, read_dir, read_to_string};
 use std::path::Path;
 
+pub type Content = Section;
+
 #[derive(Deserialize)]
 struct SectionConfig {
     title: Option<String>,

--- a/src/content.rs
+++ b/src/content.rs
@@ -15,13 +15,14 @@ struct SectionConfig {
 
 #[derive(Debug, Serialize)]
 pub struct Section {
-    pub title: String,
-    pub pages: Vec<Page>,
-    pub sections: Option<Vec<Section>>,
+    title: String,
+    pages: Option<Vec<Page>>,
+    sections: Option<Vec<Section>>,
 }
 
-pub fn get_sections(path: &Path, config: &Config) -> Result<Vec<Section>, ContentError> {
+pub fn get_section(path: &Path, config: &Config) -> Result<Section, ContentError> {
     let mut sections: Vec<Section> = Vec::new();
+    let mut pages: Vec<Page> = Vec::new();
 
     for entry in read_dir(path)? {
         let entry = entry?;
@@ -32,9 +33,22 @@ pub fn get_sections(path: &Path, config: &Config) -> Result<Vec<Section>, Conten
             let section = dir_to_section(&path, config)?;
             sections.push(section);
         }
+
+        if meta.is_file() && is_markdown(&path) {
+            let page = Page::from_path(&path, config)?;
+            pages.push(page);
+        }
     }
 
-    Ok(sections)
+    let root_section_title = get_section_title(path, config)?;
+
+    let root_section = Section {
+        title: root_section_title,
+        pages: if pages.is_empty() { None } else { Some(pages) },
+        sections: get_or_none(sections),
+    };
+
+    Ok(root_section)
 }
 
 fn title_from_index_page(path: &Path) -> Result<Option<String>, ContentError> {
@@ -50,19 +64,14 @@ fn title_from_index_page(path: &Path) -> Result<Option<String>, ContentError> {
     }
 }
 
-fn dir_to_section(path: &Path, config: &Config) -> Result<Section, ContentError> {
-    let yaml_file_path = Path::new(&path).join("_dir.yaml");
-
+fn get_section_title(path: &Path, config: &Config) -> Result<String, ContentError> {
     let title: String;
-
-    // Check if _dir.yaml exists
+    let yaml_file_path = Path::new(&path).join("_dir.yaml");
     if yaml_file_path.exists() {
         let yaml_file_str = read_to_string(&yaml_file_path)?;
         let section_config: SectionConfig = serde_yaml::from_str(&yaml_file_str)?;
         match section_config.title {
-            Some(t) => {
-                title = t;
-            }
+            Some(t) => title = t,
             None => {
                 let t = title_from_index_page(path)?;
                 title = t.unwrap_or_else(|| name_from_path(path, &config.title_config))
@@ -70,21 +79,35 @@ fn dir_to_section(path: &Path, config: &Config) -> Result<Section, ContentError>
         }
     } else {
         let t = title_from_index_page(path)?;
-        title = t.unwrap_or_else(|| name_from_path(path, &config.title_config));
-    }
+        title = t.unwrap_or_else(|| name_from_path(path, &config.title_config))
+    };
+    Ok(title)
+}
+
+fn dir_to_section(path: &Path, config: &Config) -> Result<Section, ContentError> {
+    let title = get_section_title(path, config)?;
 
     let pages = get_pages_in_dir(path, config)?;
 
-    let sub_sections = get_sections(path, config)?;
-    let sub_sections = if sub_sections.is_empty() {
-        None
-    } else {
-        Some(sub_sections)
-    };
+    let sub_section = get_section(path, config)?;
 
     Ok(Section {
         title,
-        pages,
-        sections: sub_sections,
+        pages: get_or_none(pages),
+        sections: Some(vec![sub_section]),
     })
+}
+
+// TODO: find a built-in function for this
+fn get_or_none<T>(items: Vec<T>) -> Option<Vec<T>> {
+    if items.is_empty() {
+        None
+    } else {
+        Some(items)
+    }
+}
+
+// TODO: make this more robust
+fn is_markdown(path: &Path) -> bool {
+    path.ends_with(".md")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@ use std::{
 };
 
 pub mod config;
+pub mod content;
 pub mod error;
 pub mod md;
 pub mod page;
-pub mod section;
 pub mod site;
 pub mod utils;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,10 +35,8 @@ fn main() -> Result<(), ContentError> {
             };
 
             let site = build_site(&config)?;
-
-            for section in site.sections {
-                println!("{:?}", section);
-            }
+            let site_as_str = serde_json::to_string_pretty(&site)?;
+            println!("{}", site_as_str);
         }
     }
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -5,10 +5,10 @@ use super::utils::{get_file, name_from_path};
 use comrak::{markdown_to_html, ComrakOptions};
 use gray_matter::engine::YAML;
 use gray_matter::Matter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Page {
     pub path: String,
     pub relative_path: String,

--- a/src/section.rs
+++ b/src/section.rs
@@ -4,7 +4,7 @@ use crate::get_pages_in_dir;
 use crate::md::get_document_title;
 use crate::page::Page;
 use crate::utils::{get_file, name_from_path};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fs::{metadata, read_dir, read_to_string};
 use std::path::Path;
 
@@ -13,7 +13,7 @@ struct SectionConfig {
     title: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Section {
     pub title: String,
     pub pages: Vec<Page>,

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,18 +1,18 @@
 use serde::Serialize;
 
 use crate::config::Config;
+use crate::content::{get_section, Section};
 use crate::error::ContentError;
-use crate::section::{get_sections, Section};
 
 #[derive(Serialize)]
 pub struct Site {
-    pub sections: Vec<Section>,
+    pub content: Section,
 }
 
 pub fn build_site(config: &Config) -> Result<Site, ContentError> {
-    let sections = get_sections(&config.root, config)?;
+    let content = get_section(&config.root, config)?;
 
-    let site = Site { sections };
+    let site = Site { content };
 
     Ok(site)
 }

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,12 +1,12 @@
 use serde::Serialize;
 
 use crate::config::Config;
-use crate::content::{get_section, Section};
+use crate::content::{get_section, Content};
 use crate::error::ContentError;
 
 #[derive(Serialize)]
 pub struct Site {
-    pub content: Section,
+    pub content: Content,
 }
 
 pub fn build_site(config: &Config) -> Result<Site, ContentError> {

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,7 +1,10 @@
+use serde::Serialize;
+
 use crate::config::Config;
 use crate::error::ContentError;
 use crate::section::{get_sections, Section};
 
+#[derive(Serialize)]
 pub struct Site {
     pub sections: Vec<Section>,
 }


### PR DESCRIPTION
Initially, the sections concept was broken because it ignored documents in the root docs directory. This PR addresses that.
